### PR TITLE
Add MIT license and contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to Open Room
+
+Open Room is a community building where each room is a real contribution from a real person. Thank you for being part of it.
+
+## How to contribute a room
+
+1. Visit the live site and click **+ Add Room** to reserve your spot — you'll get a room ID (e.g. `warm-harbor`)
+2. Fork this repo to your GitHub account
+3. Copy `public/registry/_template/` to `public/registry/your-room-id/`
+4. Add a background image and edit `config.json` with your hotspots
+5. Open a Pull Request with a screenshot of your room
+
+See `public/registry/_template/README.md` for the full schema reference.
+
+## Content policy
+
+All rooms must follow these guidelines:
+
+- **No hate speech** — content that attacks or dehumanizes people based on race, ethnicity, religion, gender, sexual orientation, disability, or national origin is not allowed
+- **No harassment** — content targeting or threatening specific individuals is not allowed
+- **No NSFW content** — explicit sexual or graphic violent content is not allowed
+- **No spam or advertising** — rooms should be genuine personal expressions, not promotional material
+- **No illegal content** — content that violates applicable law is not allowed
+
+## Moderation
+
+The maintainer reserves the right to reject or remove any room at their discretion, with or without explanation. This includes rooms that violate the content policy above, as well as rooms that are disruptive to the community in other ways.
+
+## Content ownership
+
+You retain ownership of everything you contribute — your background images, artwork, and any other assets in your room folder.
+
+By submitting a Pull Request, you grant the Open Room project a perpetual, non-exclusive, royalty-free license to display your content on the site. If your room is removed, this license ends.
+
+## Building codes
+
+- Background image: JPEG or WebP, **max 200KB**
+- Total room folder: **max 5MB**
+- One room per contributor

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alyssa Ward
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- Adds MIT license covering the codebase
- Adds `CONTRIBUTING.md` with builder instructions, content policy, moderation rights, and content ownership terms

## Content policy covers
- No hate speech, harassment, NSFW, spam, or illegal content
- Maintainer can remove any room at their discretion
- Builders retain ownership of their content; PR submission grants a display license

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)