### PR TITLE
Add /docs folder with developer notes

### DIFF
--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -1,0 +1,25 @@
+# Known Limitations & Future Work
+
+Things we know need addressing but aren't tackling yet.
+
+---
+
+## Multiple PRs interfering in dev
+
+**Problem:** The dev Supabase environment is shared across all open PRs. Each PR starts by mirroring prod → dev, then applying its own changes. If two PRs are open at the same time, whichever sync runs last wins — the other PR's dev state gets overwritten and its preview may be inaccurate.
+
+**When it matters:** Any time more than one PR is open simultaneously, especially if both touch room data.
+
+**Planned fix:** Supabase branching — each PR gets an isolated database branch, tied to its Vercel preview deployment. No interference between PRs.
+
+---
+
+## Room coordinate changes not synced
+
+**Problem:** Grid position (`grid_x`, `grid_y`) is stored in Supabase and is not currently managed by the sync action. If a room's coordinates need to change, it has to be done manually in the Supabase dashboard.
+
+**When it matters:** Any time a room needs to be moved on the floor plan.
+
+**Planned fix:** Add coordinate fields to `config.json` and extend the sync action to write them to Supabase on merge.
+
+---

--- a/docs/sync-architecture.md
+++ b/docs/sync-architecture.md
@@ -1,0 +1,39 @@
+# Sync Architecture
+
+How room data flows between the registry files, Supabase dev, and Supabase prod.
+
+## Overview
+
+Room data lives in two places:
+- **Registry files** (`public/registry/<room-id>/`) — the source of truth for room content (background image, hotspots, config)
+- **Supabase** — stores grid position (`grid_x`, `grid_y`), display name, and status for each room
+
+The GitHub Action `sync-rooms.yml` keeps them in sync.
+
+## Flow
+
+| Event | What happens |
+|---|---|
+| Builder reserves a room | A row is inserted into Supabase with `status: reserved` and the room's grid coordinates |
+| PR opened or updated | Registry changes are applied to **Supabase dev** so the Vercel preview reflects them |
+| PR merged to main | Registry changes are applied to **Supabase prod** — the room goes live |
+
+## What the sync action handles
+
+| Change type | Dev (on PR) | Prod (on merge) |
+|---|---|---|
+| Name change (`room_display_name` in config.json) | ✓ updated | ✓ updated |
+| Room deleted (folder removed) | ✓ status → `reserved` | ✓ status → `reserved` |
+| Room added (new config.json) | ✓ status → `active` | ✓ status → `active` |
+| Coordinate change (`grid_x`, `grid_y`) | ✗ not handled | ✗ not handled |
+
+## Supabase environments
+
+- **Prod** — live site, updated only on merge to main
+- **Dev** — preview environment, reset to match prod on every PR open/sync, then PR changes applied on top
+
+## Known limitation: multiple PRs
+
+The dev environment is shared. When multiple PRs are open simultaneously, each PR's sync overwrites dev state. Previews can interfere with each other.
+
+This is acceptable for now. See [known-limitations.md](./known-limitations.md) for the planned fix.


### PR DESCRIPTION
Adds a `/docs` folder to the repo with two pages:

- `sync-architecture.md` — how room data flows between registry files, Supabase dev, and Supabase prod
- `known-limitations.md` — things we know need fixing but aren't tackling yet (multiple PR interference, coordinate sync)

Keeps developer notes versioned with the code and visible to AI context.

Closes #21