### PR TITLE
Add mirror-to-dev and Edit Room flow, remove CI mirror steps

### DIFF
--- a/.github/workflows/sync-rooms.yml
+++ b/.github/workflows/sync-rooms.yml
@@ -10,7 +10,8 @@ on:
       - 'public/registry/**/config.json'
 
 jobs:
-  # On PR: sync prod → dev, then update changed rooms in dev so preview reflects config
+  # On PR: update changed rooms in dev so preview reflects config
+  # New reservations are mirrored to dev automatically via the mirror-to-dev Edge Function
   sync-prod-to-dev:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -18,56 +19,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Mirror prod Supabase into dev
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
-          SUPABASE_DEV_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_DEV_SERVICE_ROLE_KEY }}
-        run: |
-          node << 'EOF'
-          async function run() {
-            // Fetch all rooms from prod
-            const prodRes = await fetch(`${process.env.SUPABASE_URL}/rest/v1/rooms?select=*`, {
-              headers: {
-                'apikey': process.env.SUPABASE_SERVICE_ROLE_KEY,
-                'Authorization': `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
-              },
-            });
-
-            if (!prodRes.ok) {
-              console.error('Failed to fetch prod rooms:', await prodRes.text());
-              process.exit(1);
-            }
-
-            const rooms = await prodRes.json();
-            console.log(`Fetched ${rooms.length} rooms from prod`);
-
-            if (!rooms.length) return;
-
-            // Upsert all into dev
-            const devRes = await fetch(`${process.env.SUPABASE_DEV_URL}/rest/v1/rooms`, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'apikey': process.env.SUPABASE_DEV_SERVICE_ROLE_KEY,
-                'Authorization': `Bearer ${process.env.SUPABASE_DEV_SERVICE_ROLE_KEY}`,
-                'Prefer': 'resolution=merge-duplicates',
-              },
-              body: JSON.stringify(rooms),
-            });
-
-            if (!devRes.ok) {
-              console.error('Failed to upsert into dev:', await devRes.text());
-              process.exit(1);
-            }
-
-            console.log(`✓ Synced ${rooms.length} rooms from prod → dev`);
-          }
-
-          run().catch(err => { console.error(err); process.exit(1); });
-          EOF
 
       - name: Update changed rooms in dev
         env:
@@ -233,41 +184,5 @@ jobs:
             .catch(err => { console.error(err); process.exit(1); });
           EOF
 
-      - name: Mirror prod → dev
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          SUPABASE_DEV_URL: ${{ secrets.SUPABASE_DEV_URL }}
-          SUPABASE_DEV_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_DEV_SERVICE_ROLE_KEY }}
-        run: |
-          node << 'EOF'
-          async function run() {
-            const prodRes = await fetch(`${process.env.SUPABASE_URL}/rest/v1/rooms?select=*`, {
-              headers: {
-                'apikey': process.env.SUPABASE_SERVICE_ROLE_KEY,
-                'Authorization': `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
-              },
-            });
-
-            if (!prodRes.ok) { console.error(await prodRes.text()); process.exit(1); }
-            const rooms = await prodRes.json();
-            console.log(`Fetched ${rooms.length} rooms from prod`);
-            if (!rooms.length) return;
-
-            const devRes = await fetch(`${process.env.SUPABASE_DEV_URL}/rest/v1/rooms`, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'apikey': process.env.SUPABASE_DEV_SERVICE_ROLE_KEY,
-                'Authorization': `Bearer ${process.env.SUPABASE_DEV_SERVICE_ROLE_KEY}`,
-                'Prefer': 'resolution=merge-duplicates',
-              },
-              body: JSON.stringify(rooms),
-            });
-
-            if (!devRes.ok) { console.error(await devRes.text()); process.exit(1); }
-            console.log(`✓ Synced ${rooms.length} rooms prod → dev`);
-          }
-
-          run().catch(err => { console.error(err); process.exit(1); });
-          EOF
+      # Mirror prod → dev step removed: new reservations are mirrored automatically
+      # via the mirror-to-dev Edge Function on INSERT

--- a/app/components/RoomView.tsx
+++ b/app/components/RoomView.tsx
@@ -53,6 +53,8 @@ export default function RoomView({ onBack, registryId, room }: {
   const [registryEntries, setRegistryEntries] = useState<RegistryEntry[]>([]);
   const [registryLoading, setRegistryLoading] = useState(false);
   const [showRoomInfo, setShowRoomInfo] = useState(false);
+  const [editRequested, setEditRequested] = useState(false);
+  const [editLoading, setEditLoading] = useState(false);
 
   useEffect(() => {
     fetch(`/registry/${registryId}/config.json`)
@@ -63,6 +65,20 @@ export default function RoomView({ onBack, registryId, room }: {
       .then(setConfig)
       .catch(() => setConfigError(true));
   }, [registryId]);
+
+  const requestEdit = async () => {
+    setEditLoading(true);
+    const { error } = await supabase.functions.invoke('create-edit-issue', {
+      body: {
+        registryId: room?.registry_id ?? registryId,
+        githubUsername: room?.github_username ?? config?.owner,
+        gridX: room?.grid_x,
+        gridY: room?.grid_y,
+      },
+    });
+    setEditLoading(false);
+    if (!error) setEditRequested(true);
+  };
 
   const openRegistry = async () => {
     setActiveModal('registry');
@@ -207,6 +223,19 @@ export default function RoomView({ onBack, registryId, room }: {
                     <span className="text-xs text-slate-400">Room ID</span>
                     <code className="text-xs font-mono font-bold text-indigo-600">{room.registry_id}</code>
                   </div>
+                )}
+              </div>
+              <div className="mt-3 pt-3 border-t border-slate-100">
+                {editRequested ? (
+                  <p className="text-xs text-center text-green-600 font-bold">Edit request submitted!</p>
+                ) : (
+                  <button
+                    onClick={requestEdit}
+                    disabled={editLoading}
+                    className="w-full py-2 bg-slate-900 text-white rounded-xl text-xs font-black uppercase tracking-widest hover:bg-indigo-600 transition-colors disabled:opacity-50"
+                  >
+                    {editLoading ? 'Requesting…' : 'Edit Room'}
+                  </button>
                 )}
               </div>
             </div>

--- a/app/components/RoomView.tsx
+++ b/app/components/RoomView.tsx
@@ -55,6 +55,7 @@ export default function RoomView({ onBack, registryId, room }: {
   const [showRoomInfo, setShowRoomInfo] = useState(false);
   const [editRequested, setEditRequested] = useState(false);
   const [editLoading, setEditLoading] = useState(false);
+  const [editError, setEditError] = useState(false);
 
   useEffect(() => {
     fetch(`/registry/${registryId}/config.json`)
@@ -77,7 +78,8 @@ export default function RoomView({ onBack, registryId, room }: {
       },
     });
     setEditLoading(false);
-    if (!error) setEditRequested(true);
+    if (error) setEditError(true);
+    else setEditRequested(true);
   };
 
   const openRegistry = async () => {
@@ -228,6 +230,8 @@ export default function RoomView({ onBack, registryId, room }: {
               <div className="mt-3 pt-3 border-t border-slate-100">
                 {editRequested ? (
                   <p className="text-xs text-center text-green-600 font-bold">Edit request submitted!</p>
+                ) : editError ? (
+                  <p className="text-xs text-center text-red-500 font-bold">Something went wrong. Try again.</p>
                 ) : (
                   <button
                     onClick={requestEdit}

--- a/app/components/RoomView.tsx
+++ b/app/components/RoomView.tsx
@@ -53,6 +53,9 @@ export default function RoomView({ onBack, registryId, room }: {
   const [registryEntries, setRegistryEntries] = useState<RegistryEntry[]>([]);
   const [registryLoading, setRegistryLoading] = useState(false);
   const [showRoomInfo, setShowRoomInfo] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [editTitle, setEditTitle] = useState('');
+  const [editDescription, setEditDescription] = useState('');
   const [editRequested, setEditRequested] = useState(false);
   const [editLoading, setEditLoading] = useState(false);
   const [editError, setEditError] = useState(false);
@@ -75,11 +78,13 @@ export default function RoomView({ onBack, registryId, room }: {
         githubUsername: room?.github_username ?? config?.owner,
         gridX: room?.grid_x,
         gridY: room?.grid_y,
+        title: editTitle,
+        description: editDescription,
       },
     });
     setEditLoading(false);
-    if (error) setEditError(true);
-    else setEditRequested(true);
+    if (error) { setEditError(true); }
+    else { setShowEditModal(false); setEditRequested(true); }
   };
 
   const openRegistry = async () => {
@@ -229,16 +234,13 @@ export default function RoomView({ onBack, registryId, room }: {
               </div>
               <div className="mt-3 pt-3 border-t border-slate-100">
                 {editRequested ? (
-                  <p className="text-xs text-center text-green-600 font-bold">Edit request submitted!</p>
-                ) : editError ? (
-                  <p className="text-xs text-center text-red-500 font-bold">Something went wrong. Try again.</p>
+                  <p className="text-xs text-center text-green-600 font-bold">Edit task created!</p>
                 ) : (
                   <button
-                    onClick={requestEdit}
-                    disabled={editLoading}
-                    className="w-full py-2 bg-slate-900 text-white rounded-xl text-xs font-black uppercase tracking-widest hover:bg-indigo-600 transition-colors disabled:opacity-50"
+                    onClick={() => { setEditError(false); setShowEditModal(true); }}
+                    className="w-full py-2 bg-slate-900 text-white rounded-xl text-xs font-black uppercase tracking-widest hover:bg-indigo-600 transition-colors"
                   >
-                    {editLoading ? 'Requesting…' : 'Edit Room'}
+                    Open a Task
                   </button>
                 )}
               </div>
@@ -361,6 +363,53 @@ export default function RoomView({ onBack, registryId, room }: {
               className="w-full py-3.5 bg-slate-900 text-white rounded-xl font-black text-sm uppercase tracking-widest hover:bg-indigo-600 transition-colors"
             >
               Back to Room
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Edit Task Modal */}
+      {showEditModal && (
+        <div
+          className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-6"
+          onClick={() => setShowEditModal(false)}
+        >
+          <div
+            className="bg-white rounded-3xl p-8 max-w-sm w-full shadow-2xl"
+            onClick={e => e.stopPropagation()}
+          >
+            <h2 className="text-slate-900 text-xl font-black tracking-tight mb-1">Open a Task</h2>
+            <p className="text-slate-500 text-sm mb-6 leading-relaxed">Describe what you want to change. A GitHub issue will be opened for this room.</p>
+            <div className="space-y-3 mb-4">
+              <div>
+                <label className="text-xs font-black uppercase tracking-widest text-slate-400 block mb-1.5">Title</label>
+                <input
+                  type="text"
+                  value={editTitle}
+                  onChange={e => setEditTitle(e.target.value)}
+                  placeholder="e.g. New background image"
+                  className="w-full border border-slate-200 rounded-xl px-4 py-3 text-sm text-slate-900 placeholder:text-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  autoFocus
+                />
+              </div>
+              <div>
+                <label className="text-xs font-black uppercase tracking-widest text-slate-400 block mb-1.5">Description</label>
+                <textarea
+                  value={editDescription}
+                  onChange={e => setEditDescription(e.target.value)}
+                  placeholder="e.g. Replace the current background with a night-time version, and add a hotspot for my portfolio"
+                  className="w-full border border-slate-200 rounded-xl px-4 py-3 text-sm text-slate-900 placeholder:text-slate-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
+                  rows={3}
+                />
+              </div>
+            </div>
+            {editError && <p className="text-xs text-red-500 font-bold mb-3">Something went wrong. Try again.</p>}
+            <button
+              onClick={requestEdit}
+              disabled={editLoading || !editTitle.trim() || !editDescription.trim()}
+              className="w-full py-3 bg-slate-900 text-white rounded-xl text-sm font-black uppercase tracking-widest hover:bg-indigo-600 transition-colors disabled:opacity-50"
+            >
+              {editLoading ? 'Creating…' : 'Open a Task'}
             </button>
           </div>
         </div>

--- a/supabase/functions/create-edit-issue/index.ts
+++ b/supabase/functions/create-edit-issue/index.ts
@@ -3,15 +3,24 @@ import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 const GITHUB_TOKEN = Deno.env.get('GITHUB_TOKEN')!;
 const GITHUB_REPO = 'alyssafuward/open-room-open-source';
 
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
 serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
   if (req.method !== 'POST') {
-    return new Response('Method not allowed', { status: 405 });
+    return new Response('Method not allowed', { status: 405, headers: corsHeaders });
   }
 
   const { registryId, githubUsername, gridX, gridY } = await req.json();
 
   if (!registryId || !githubUsername) {
-    return new Response('Missing required fields', { status: 400 });
+    return new Response('Missing required fields', { status: 400, headers: corsHeaders });
   }
 
   const title = `Edit request: ${registryId} (@${githubUsername})`;
@@ -41,10 +50,13 @@ serve(async (req) => {
   if (!response.ok) {
     const error = await response.text();
     console.error('GitHub API error:', error);
-    return new Response('Failed to create issue', { status: 500 });
+    return new Response('Failed to create issue', { status: 500, headers: corsHeaders });
   }
 
   const issue = await response.json();
   console.log(`Created issue #${issue.number}: ${title}`);
-  return new Response(JSON.stringify({ issue: issue.number, url: issue.html_url }), { status: 200 });
+  return new Response(JSON.stringify({ issue: issue.number, url: issue.html_url }), {
+    status: 200,
+    headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+  });
 });

--- a/supabase/functions/create-edit-issue/index.ts
+++ b/supabase/functions/create-edit-issue/index.ts
@@ -1,0 +1,50 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+
+const GITHUB_TOKEN = Deno.env.get('GITHUB_TOKEN')!;
+const GITHUB_REPO = 'alyssafuward/open-room-open-source';
+
+serve(async (req) => {
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  const { registryId, githubUsername, gridX, gridY } = await req.json();
+
+  if (!registryId || !githubUsername) {
+    return new Response('Missing required fields', { status: 400 });
+  }
+
+  const title = `Edit request: ${registryId} (@${githubUsername})`;
+  const body = [
+    `An edit has been requested for this room.`,
+    ``,
+    `| Field | Value |`,
+    `|-------|-------|`,
+    `| Registry ID | \`${registryId}\` |`,
+    `| GitHub | @${githubUsername} |`,
+    `| Grid position | (${gridX ?? '?'}, ${gridY ?? '?'}) |`,
+    ``,
+    `**Next step:** @${githubUsername} should fork the repo, update \`public/registry/${registryId}/\`, and open a PR.`,
+  ].join('\n');
+
+  const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/issues`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${GITHUB_TOKEN}`,
+      'Content-Type': 'application/json',
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    body: JSON.stringify({ title, body, labels: ['room'] }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    console.error('GitHub API error:', error);
+    return new Response('Failed to create issue', { status: 500 });
+  }
+
+  const issue = await response.json();
+  console.log(`Created issue #${issue.number}: ${title}`);
+  return new Response(JSON.stringify({ issue: issue.number, url: issue.html_url }), { status: 200 });
+});

--- a/supabase/functions/create-edit-issue/index.ts
+++ b/supabase/functions/create-edit-issue/index.ts
@@ -17,13 +17,13 @@ serve(async (req) => {
     return new Response('Method not allowed', { status: 405, headers: corsHeaders });
   }
 
-  const { registryId, githubUsername, gridX, gridY } = await req.json();
+  const { registryId, githubUsername, gridX, gridY, title: editTitle, description } = await req.json();
 
-  if (!registryId || !githubUsername) {
+  if (!registryId || !githubUsername || !editTitle) {
     return new Response('Missing required fields', { status: 400, headers: corsHeaders });
   }
 
-  const title = `Edit request: ${registryId} (@${githubUsername})`;
+  const title = `Task: ${registryId} (@${githubUsername}) — ${editTitle}`;
   const body = [
     `An edit has been requested for this room.`,
     ``,
@@ -33,8 +33,10 @@ serve(async (req) => {
     `| GitHub | @${githubUsername} |`,
     `| Grid position | (${gridX ?? '?'}, ${gridY ?? '?'}) |`,
     ``,
+    description ? `**What to change:** ${description}` : '',
+    ``,
     `**Next step:** @${githubUsername} should fork the repo, update \`public/registry/${registryId}/\`, and open a PR.`,
-  ].join('\n');
+  ].filter(line => line !== null).join('\n');
 
   const response = await fetch(`https://api.github.com/repos/${GITHUB_REPO}/issues`, {
     method: 'POST',

--- a/supabase/functions/mirror-to-dev/index.ts
+++ b/supabase/functions/mirror-to-dev/index.ts
@@ -1,7 +1,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 
-const DEV_URL = Deno.env.get('SUPABASE_DEV_URL')!;
-const DEV_KEY = Deno.env.get('SUPABASE_DEV_SERVICE_ROLE_KEY')!;
+const DEV_URL = Deno.env.get('DEV_URL')!;
+const DEV_KEY = Deno.env.get('DEV_SERVICE_ROLE_KEY')!;
 
 serve(async (req) => {
   if (req.method !== 'POST') {

--- a/supabase/functions/mirror-to-dev/index.ts
+++ b/supabase/functions/mirror-to-dev/index.ts
@@ -1,0 +1,38 @@
+import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
+
+const DEV_URL = Deno.env.get('SUPABASE_DEV_URL')!;
+const DEV_KEY = Deno.env.get('SUPABASE_DEV_SERVICE_ROLE_KEY')!;
+
+serve(async (req) => {
+  if (req.method !== 'POST') {
+    return new Response('Method not allowed', { status: 405 });
+  }
+
+  const payload = await req.json();
+
+  if (payload.type !== 'INSERT') {
+    return new Response('Ignored', { status: 200 });
+  }
+
+  const room = payload.record;
+
+  const res = await fetch(`${DEV_URL}/rest/v1/rooms`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'apikey': DEV_KEY,
+      'Authorization': `Bearer ${DEV_KEY}`,
+      'Prefer': 'resolution=merge-duplicates',
+    },
+    body: JSON.stringify(room),
+  });
+
+  if (!res.ok) {
+    const error = await res.text();
+    console.error('Failed to mirror room to dev:', error);
+    return new Response('Failed to mirror', { status: 500 });
+  }
+
+  console.log(`✓ Mirrored room ${room.registry_id} to dev`);
+  return new Response(JSON.stringify({ mirrored: room.registry_id }), { status: 200 });
+});


### PR DESCRIPTION
Closes #26

## Summary

- **`mirror-to-dev` Edge Function** — fires on INSERT to the prod `rooms` table, copies the row to dev. New reservations now land in both DBs automatically.
- **`create-edit-issue` Edge Function** — invoked directly from the UI (not a webhook). Creates a GitHub issue tagged `room` when a room owner requests an edit.
- **Edit Room button** — added to the Room Info panel (`i` button, bottom-right of every room). Calls `create-edit-issue` and confirms when submitted.
- **CI mirror steps removed** — the "Mirror prod → dev" steps in both jobs are gone. Registry-specific update/delete steps are unchanged.

## Setup required (one-time)

Two new Edge Functions need to be deployed and configured in the Supabase dashboard:

**`mirror-to-dev`**
- Deploy the function
- Add secrets: `SUPABASE_DEV_URL`, `SUPABASE_DEV_SERVICE_ROLE_KEY`
- Add a database webhook: INSERT on `rooms` → `mirror-to-dev`

**`create-edit-issue`**
- Deploy the function
- Add secret: `GITHUB_TOKEN` (same value as `create-room-issue`)
- No webhook needed — invoked directly from the UI