### PR TITLE
Hide deleted rooms from floor plan

### DIFF
--- a/.github/workflows/sync-rooms.yml
+++ b/.github/workflows/sync-rooms.yml
@@ -109,7 +109,7 @@ jobs:
                     'Authorization': `Bearer ${process.env.SUPABASE_DEV_SERVICE_ROLE_KEY}`,
                     'Prefer': 'return=representation',
                   },
-                  body: JSON.stringify({ status: 'deleted' }),
+                  body: JSON.stringify({ status: 'deleted', grid_x: null, grid_y: null }),
                 }
               );
               if (!patch.ok) { console.error(`Failed to mark deleted: ${id}`, await patch.json()); process.exit(1); }
@@ -200,7 +200,7 @@ jobs:
                     'Authorization': `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY}`,
                     'Prefer': 'return=representation',
                   },
-                  body: JSON.stringify({ status: 'deleted' }),
+                  body: JSON.stringify({ status: 'deleted', grid_x: null, grid_y: null }),
                 }
               );
               if (!patch.ok) { console.error(`Failed to mark deleted: ${id}`, await patch.json()); process.exit(1); }
@@ -253,7 +253,7 @@ jobs:
                     'Authorization': `Bearer ${process.env.SUPABASE_DEV_SERVICE_ROLE_KEY}`,
                     'Prefer': 'return=representation',
                   },
-                  body: JSON.stringify({ status: 'deleted' }),
+                  body: JSON.stringify({ status: 'deleted', grid_x: null, grid_y: null }),
                 }
               );
               if (!patch.ok) { console.error(`Failed to mark deleted in dev: ${id}`, await patch.json()); process.exit(1); }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ function OpenRoomInner() {
   const [successRoom, setSuccessRoom] = useState<{ room: any; roomId: string } | null>(null);
 
   const refreshRooms = useCallback(async () => {
-    const { data } = await supabase.from('rooms').select('*');
+    const { data } = await supabase.from('rooms').select('*').neq('status', 'deleted');
     let roomList = data || [];
     
     // Check for the center piece: The Common Room


### PR DESCRIPTION
Closes #64

## Change
Adds `.neq('status', 'deleted')` to the floor plan rooms query so deleted rooms no longer appear on the grid.

## Test plan
- [ ] open-ridge no longer appears on the live floor plan after merge
- [ ] Reserved and active rooms still show correctly