### PR TITLE
open_image hotspot: click navigates to URL when url field is present

### DIFF
--- a/app/components/RoomView.tsx
+++ b/app/components/RoomView.tsx
@@ -137,7 +137,11 @@ export default function RoomView({ onBack, registryId, room }: {
     } else if (hotspot.action === 'open_url' && hotspot.url) {
       window.open(hotspot.url, '_blank', 'noopener,noreferrer');
     } else if (hotspot.action === 'open_image' && hotspot.image_url) {
-      setActiveImage({ url: hotspot.image_url, label: hotspot.label });
+      if (hotspot.url) {
+        window.open(hotspot.url, '_blank', 'noopener,noreferrer');
+      } else {
+        setActiveImage({ url: hotspot.image_url, label: hotspot.label });
+      }
     } else if (hotspot.action === 'open_modal') {
       if (hotspot.modal === 'registry') {
         openRegistry();
@@ -374,11 +378,7 @@ export default function RoomView({ onBack, registryId, room }: {
           onClick={() => setActiveImage(null)}
         >
           <div className="relative max-w-2xl w-full" onClick={e => e.stopPropagation()}>
-            <img
-              src={activeImage.url}
-              alt={activeImage.label}
-              className="w-full h-auto rounded-2xl shadow-2xl"
-            />
+            <img src={activeImage.url} alt={activeImage.label} className="w-full h-auto rounded-2xl shadow-2xl" />
             <p className="text-white/70 text-xs text-center mt-3">{activeImage.label}</p>
           </div>
         </div>

--- a/public/registry/soft-grove/pages/100-days/config.json
+++ b/public/registry/soft-grove/pages/100-days/config.json
@@ -26,7 +26,8 @@
       "width": 20,
       "height": 30,
       "action": "open_image",
-      "image_url": "/registry/soft-grove/pages/100-days/assets/02-dreaming.jpeg"
+      "image_url": "/registry/soft-grove/pages/100-days/assets/02-dreaming.jpeg",
+      "url": "https://createwithalyssa.substack.com/p/day-13-of-100-dreaming-is-free"
     },
     {
       "id": "img-03",


### PR DESCRIPTION
## Summary

- When an `open_image` hotspot has a `url` field, clicking it navigates to that URL directly instead of opening the image modal
- Backwards compatible — hotspots with no `url` continue to open the full-screen modal as before
- No config changes required for existing rooms

## Test plan
- [ ] Click an `open_image` hotspot with a `url` — should open URL in new tab
- [ ] Click an `open_image` hotspot without a `url` — should still open image modal

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)