### PR TITLE
Builder onboarding: ask for GitHub username, add pre-PR safety checklist

### DIFF
--- a/.claude/skills/open-room-dev/SKILL.md
+++ b/.claude/skills/open-room-dev/SKILL.md
@@ -39,15 +39,25 @@ Welcome to Open Room! What would you like to work on?
 
 ---
 
-## Step 2: Room ID (room work only)
+## Step 2: GitHub username (room work only)
 
 If they chose 1 or 2, ask:
 
 ---
 
-What's your room registry ID? It looks something like `warm-harbor` or `soft-grove`. You would have gotten it when you reserved your spot on the floor plan.
+What's your GitHub username? I'll use it to look up your reserved room.
 
-If you haven't reserved a room yet, visit the live site, click **+ Add Room**, and come back with your ID.
+---
+
+Then run:
+
+```bash
+gh issue list --repo alyssafuward/open-room-open-source --label room --search "@their-username"
+```
+
+Find the issue that matches their username — it will contain their room ID (e.g. `warm-harbor`). Confirm the room ID with them before moving on.
+
+If no issue is found, they haven't reserved a room yet. Tell them to visit the live site, click **+ Add Room**, fill out the form, and come back — a GitHub issue will be created automatically with their room ID.
 
 ---
 
@@ -166,7 +176,25 @@ git push -u origin <branch-name>
 
 ---
 
-## Step 6: Open a PR
+## Step 6: Safety check before submitting
+
+Before opening a PR, walk them through a quick review. Keep it light and conversational — frame it as a final look, not an audit:
+
+---
+
+Before we submit, let's do a quick once-over:
+
+1. **Links** — if you added any clickable links to your room, do they go where you expect? Anyone who visits your room will be able to click them.
+2. **Background image** — are you comfortable sharing this image publicly? Make sure you have the right to use it (your own photo, AI-generated, or clearly licensed).
+3. **Your name and details** — your GitHub username will appear as the room owner. Does everything look right?
+
+---
+
+If anything looks off, fix it before moving on. Once the PR is merged, the room goes live for everyone.
+
+---
+
+## Step 7: Open a PR
 
 When they're happy with the changes, offer to open a pull request.
 
@@ -182,7 +210,7 @@ Ready to submit? I'll open a pull request to add your changes to the live projec
 gh pr create --title "..." --body "..."
 ```
 
-Return the full PR URL (e.g. `https://github.com/alyssafuward/open-room-open-source/pull/16`) as a clickable link — not just the issue reference. Then walk them through the Vercel approval:
+Return the full PR URL (e.g. `https://github.com/alyssafuward/open-room-open-source/pull/16`) as a clickable link — not just the issue reference. Then walk them through what happens next:
 
 ---
 

--- a/.claude/skills/open-room-dev/SKILL.md
+++ b/.claude/skills/open-room-dev/SKILL.md
@@ -52,7 +52,7 @@ What's your GitHub username? I'll use it to look up your reserved room.
 Then run:
 
 ```bash
-gh issue list --repo alyssafuward/open-room-open-source --label room --search "@their-username"
+gh issue list --repo alyssafuward/open-room-open-source --label room --search "their-username"
 ```
 
 Find the issue that matches their username — it will contain their room ID (e.g. `warm-harbor`). Confirm the room ID with them before moving on.

--- a/.claude/skills/open-room-dev/SKILL.md
+++ b/.claude/skills/open-room-dev/SKILL.md
@@ -49,13 +49,15 @@ What's your GitHub username? I'll use it to look up your reserved room.
 
 ---
 
+If they don't know what GitHub is or don't remember signing in: explain that the reservation form required a GitHub login, so they do have an account. Ask if they remember the email they used — that can help them recover their username at github.com. Once they have it, continue.
+
 Then run:
 
 ```bash
 gh issue list --repo alyssafuward/open-room-open-source --label room --search "their-username"
 ```
 
-Find the issue that matches their username — it will contain their room ID (e.g. `warm-harbor`). Confirm the room ID with them before moving on.
+Find the issue that matches their username — it will contain their room ID (e.g. `warm-harbor`). Share the direct link to the issue so they can confirm it's theirs, even if they don't remember the room ID. The issue title will show both the room ID and their username.
 
 If no issue is found, they haven't reserved a room yet. Tell them to visit the live site, click **+ Add Room**, fill out the form, and come back — a GitHub issue will be created automatically with their room ID.
 
@@ -94,6 +96,8 @@ Ask for a description of what they plan to do:
 Give me a quick description of what you're planning. A sentence or two is fine — just enough to capture the intent.
 
 ---
+
+If they're vague (e.g. "make it look cool", "I don't know yet"), help them get specific with a follow-up: ask what image or theme they have in mind, or what they'd want someone to see or feel when they walk into their room. Use their answer to write the issue description yourself — don't make them write it.
 
 Create a GitHub issue with their description as the body, note the issue number, then create the branch.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Once their Pull Request is merged, their room goes live on the floor plan.
 When a Builder starts a session, ask for their GitHub username, then look up their reserved room:
 
 ```bash
-gh issue list --label room --search "@their-username"
+gh issue list --label room --search "their-username"
 ```
 
 The issue will contain their room ID (e.g. `warm-harbor`). Confirm it with them before moving on.
@@ -80,7 +80,7 @@ If a Builder wants to update their room after it's already live, they use the **
 
 To find open edit tasks for a specific builder:
 ```
-gh issue list --label room --search "(@github-username)"
+gh issue list --label room --search "github-username"
 ```
 
 Once a task issue is open, the Builder forks the repo, makes their changes to `public/registry/their-room-id/`, and opens a Pull Request referencing the issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,15 @@ Once their Pull Request is merged, their room goes live on the floor plan.
 
 ## Onboarding
 
-When a Builder starts a session, ask: **"Do you already have your room ID?"**
+When a Builder starts a session, ask for their GitHub username, then look up their reserved room:
 
-- **Yes** → go straight to setup (fork, copy template, build)
-- **No** → tell them to visit the live site first, click **+ Add Room**, and reserve their spot. They'll get a room ID (e.g. `warm-harbor`) that becomes their folder name. A GitHub issue is automatically opened when they reserve — they can find it with `gh issue list --label room`.
+```bash
+gh issue list --label room --search "@their-username"
+```
+
+The issue will contain their room ID (e.g. `warm-harbor`). Confirm it with them before moving on.
+
+If no issue is found, they haven't reserved yet — tell them to visit the live site, click **+ Add Room**, and come back. A GitHub issue with their room ID is created automatically when they reserve.
 
 ## The setup flow (handle all of this yourself)
 


### PR DESCRIPTION
Closes #93

## Summary
- Ask for GitHub username instead of room ID — look up their reservation issue automatically
- Update `CLAUDE.md` onboarding section to match
- Add pre-PR safety checklist: link safety, image rights, identity review

## Test plan
- [ ] Activate `/open-room-dev`, choose option 1, confirm it asks for GitHub username and finds the issue
- [ ] Walk through to PR step and confirm safety checklist appears