### PR TITLE
Add onboarding waitlist to window hotspot in room-001

### DIFF
--- a/app/components/RoomView.tsx
+++ b/app/components/RoomView.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '@supabase/supabase-js';
 import DiagramModal from './DiagramModal';
+import WaitlistModal from './WaitlistModal';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -513,6 +514,11 @@ export default function RoomView({ onBack, registryId, room }: {
       {/* Diagram Modal */}
       {activeModal === 'diagram' && (
         <DiagramModal onClose={() => setActiveModal(null)} />
+      )}
+
+      {/* Waitlist Modal */}
+      {activeModal === 'waitlist' && (
+        <WaitlistModal onClose={() => setActiveModal(null)} />
       )}
 
       {/* Registry Modal */}

--- a/app/components/WaitlistModal.tsx
+++ b/app/components/WaitlistModal.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+const WAITLIST = [
+  { position: 1,  initials: 'OO' },
+  { position: 2,  initials: 'BN' },
+  { position: 3,  initials: 'OT' },
+  { position: 4,  initials: 'TF' },
+  { position: 5,  initials: 'DIK' },
+  { position: 6,  initials: 'BM' },
+  { position: 7,  initials: 'NW' },
+  { position: 8,  initials: 'TL' },
+  { position: 9,  initials: 'ED' },
+  { position: 10, initials: 'ST' },
+  { position: 11, initials: 'EP' },
+];
+
+export default function WaitlistModal({ onClose }: { onClose: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 bg-slate-950/70 backdrop-blur-sm z-50 flex items-center justify-center p-6"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-3xl p-8 max-w-xs w-full shadow-2xl"
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 className="text-slate-900 text-xl font-black tracking-tight mb-5">List</h2>
+        <ol className="space-y-2">
+          {WAITLIST.map(({ position, initials }) => (
+            <li key={position} className="flex items-center gap-3">
+              <span className="text-xs font-black text-slate-300 w-5 text-right">{position}</span>
+              <span className="text-sm font-mono font-bold text-slate-700">{initials}</span>
+            </li>
+          ))}
+        </ol>
+        <button
+          onClick={onClose}
+          className="mt-6 w-full py-3 bg-slate-900 text-white rounded-xl font-black text-xs uppercase tracking-widest hover:bg-indigo-600 transition-colors"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/public/registry/room-001/config.json
+++ b/public/registry/room-001/config.json
@@ -35,6 +35,16 @@
       "modal": "registry"
     },
     {
+      "id": "window-list",
+      "label": "Window",
+      "x": 10,
+      "y": 20,
+      "width": 5,
+      "height": 40,
+      "action": "open_modal",
+      "modal": "waitlist"
+    },
+    {
       "id": "exit-door",
       "label": "Exit to Floor Plan",
       "x": 79,


### PR DESCRIPTION
Adds a clickable window hotspot in the Common Room that opens a modal with an encoded onboarding list.

- Hotspot at x:10 y:20 w:5 h:40 (left window area)
- 11 entries displayed as shifted initials (one letter forward — light privacy layer / easter egg)
- No database, no file to manage — lives entirely in WaitlistModal.tsx

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)