### PR TITLE
Add /api/dev/current-branch route for local preview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,13 +88,15 @@ Once a task issue is open, the Builder forks the repo, makes their changes to `p
 
 ## Launching locally
 
-After making changes, offer to launch a local preview so the Builder can see their room before opening a PR:
+After making changes, offer to launch a local preview so the Builder can see their room before opening a PR. Run this from their cloned fork (no `.env` or Supabase config needed):
 
 ```bash
-cd ~/src/open-room-open-source && npm run dev
+cd ~/src/<their-fork-folder> && npm run dev
 ```
 
 Then tell them: "I've started a local preview — open http://localhost:3000 to see your room."
+
+The local preview auto-detects rooms in `public/registry/` and highlights the one matching the current branch. If only one room exists it redirects straight to it.
 
 If a server is already running it will print the active port (e.g. 3002) — use that instead.
 

--- a/app/api/dev/current-branch/route.ts
+++ b/app/api/dev/current-branch/route.ts
@@ -1,0 +1,12 @@
+import { execSync } from 'child_process';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', { encoding: 'utf8' }).trim();
+    const match = branch.match(/^room\/\d+-(.+)$/);
+    return NextResponse.json({ roomId: match ? match[1] : null });
+  } catch {
+    return NextResponse.json({ roomId: null });
+  }
+}


### PR DESCRIPTION
## Summary
- Creates `app/api/dev/current-branch/route.ts` — reads the current git branch, parses the room ID from `room/NNN-room-id` format, returns `{ roomId: string | null }`
- Fixes the local preview hanging on "Loading…" since `LocalPreview` called this route but it didn't exist
- Updates CLAUDE.md to clarify that no `.env` or Supabase config is needed for local preview

Closes #138