### PR TITLE
Remove waitlist modal and fix adjacency to orthogonal only

### DIFF
--- a/app/components/RoomView.tsx
+++ b/app/components/RoomView.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '@supabase/supabase-js';
 import DiagramModal from './DiagramModal';
-import WaitlistModal from './WaitlistModal';
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -514,11 +513,6 @@ export default function RoomView({ onBack, registryId, room }: {
       {/* Diagram Modal */}
       {activeModal === 'diagram' && (
         <DiagramModal onClose={() => setActiveModal(null)} />
-      )}
-
-      {/* Waitlist Modal */}
-      {activeModal === 'waitlist' && (
-        <WaitlistModal onClose={() => setActiveModal(null)} />
       )}
 
       {/* Registry Modal */}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -175,7 +175,7 @@ function OpenRoomInner() {
 
           const isAdjacent = Array.from(occupied).some(coord => {
             const [ox, oy] = coord.split(',').map(Number);
-            return Math.max(Math.abs(ox - x), Math.abs(oy - y)) === 1;
+            return Math.abs(ox - x) + Math.abs(oy - y) === 1;
           });
 
           if (!isAdjacent) return <div key={`${x}-${y}`} className="w-28 h-28" />;

--- a/public/registry/room-001/config.json
+++ b/public/registry/room-001/config.json
@@ -35,16 +35,6 @@
       "modal": "registry"
     },
     {
-      "id": "window-list",
-      "label": "Window",
-      "x": 15,
-      "y": 15,
-      "width": 7,
-      "height": 40,
-      "action": "open_modal",
-      "modal": "waitlist"
-    },
-    {
       "id": "anchors-slides",
       "label": "Open Room Onboarding",
       "x": 25,


### PR DESCRIPTION
Closes #146

- Removes the window/waitlist hotspot from the Welcome Room (room-001)
- Removes `WaitlistModal` import and render from `RoomView`
- Changes floor plan available-cell detection from Chebyshev distance (includes diagonals) to Manhattan distance (up/down/left/right only)