### PR TITLE
Lock room cells during reservation to prevent double-booking

### DIFF
--- a/app/components/ReservationModal.tsx
+++ b/app/components/ReservationModal.tsx
@@ -24,15 +24,21 @@ function generateRoomId() {
   return `${adj}-${noun}`;
 }
 
-export default function ReservationModal({ x, y, onClose, onSuccess }: {
+export default function ReservationModal({ x, y, lockId, onClose, onSuccess }: {
   x: number;
   y: number;
+  lockId: string;
   onClose: () => void;
   onSuccess: (room: any, roomId: string) => void;
 }) {
   const [form, setForm] = useState({ name: '', github: '', email: '' });
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+
+  const handleClose = async () => {
+    await supabase!.from('rooms').delete().eq('id', lockId);
+    onClose();
+  };
 
   const set = (field: string, value: string) => {
     setForm(prev => ({ ...prev, [field]: value }));
@@ -62,9 +68,9 @@ export default function ReservationModal({ x, y, onClose, onSuccess }: {
       attempts++;
     }
 
-    const { data, error: insertError } = await supabase!
+    const { data, error: updateError } = await supabase!
       .from('rooms')
-      .insert([{
+      .update({
         name: roomId,
         owner_name: form.name,
         owner_id: form.github,
@@ -74,15 +80,14 @@ export default function ReservationModal({ x, y, onClose, onSuccess }: {
         registry_id: roomId,
         status: 'reserved',
         reserved_at: new Date().toISOString(),
-        grid_x: x,
-        grid_y: y,
-      }])
+      })
+      .eq('id', lockId)
       .select()
       .single();
 
     setLoading(false);
 
-    if (insertError) {
+    if (updateError) {
       setError('Something went wrong. Please try again.');
       return;
     }
@@ -93,7 +98,7 @@ export default function ReservationModal({ x, y, onClose, onSuccess }: {
   return (
     <div
       className="fixed inset-0 bg-stone-900/60 backdrop-blur-sm z-50 overflow-y-auto p-6"
-      onClick={onClose}
+      onClick={handleClose}
     >
       <div
         className="bg-white rounded-3xl p-8 max-w-md w-full shadow-2xl mx-auto my-6"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,7 +26,7 @@ function OpenRoomInner() {
   const [rooms, setRooms] = useState<any[]>([]);
   const [myId, setMyId] = useState<string>('');
   const [isHelpOpen, setIsHelpOpen] = useState(false);
-  const [reserving, setReserving] = useState<{ x: number; y: number } | null>(null);
+  const [reserving, setReserving] = useState<{ x: number; y: number; lockId: string } | null>(null);
   const [successRoom, setSuccessRoom] = useState<{ room: any; roomId: string } | null>(null);
 
   const refreshRooms = useCallback(async () => {
@@ -117,8 +117,12 @@ function OpenRoomInner() {
   }
 
   // --- DYNAMIC FLOORPLAN LOGIC ---
-  const xValues = rooms.length > 0 ? rooms.map(r => r.grid_x) : [0];
-  const yValues = rooms.length > 0 ? rooms.map(r => r.grid_y) : [0];
+  const activeRooms = rooms.filter(r =>
+    r.status !== 'locking' || !r.locked_at || Date.now() - new Date(r.locked_at).getTime() < LOCK_TTL_MS
+  );
+
+  const xValues = activeRooms.length > 0 ? activeRooms.map(r => r.grid_x) : [0];
+  const yValues = activeRooms.length > 0 ? activeRooms.map(r => r.grid_y) : [0];
   const minX = Math.min(...xValues) - 1;
   const maxX = Math.max(...xValues) + 1;
   const minY = Math.min(...yValues) - 1;
@@ -126,10 +130,22 @@ function OpenRoomInner() {
 
   const xRange = Array.from({ length: maxX - minX + 1 }, (_, i) => minX + i);
   const yRange = Array.from({ length: maxY - minY + 1 }, (_, i) => minY + i);
-  const occupied = new Set(rooms.map(r => `${r.grid_x},${r.grid_y}`));
+  const occupied = new Set(activeRooms.map(r => `${r.grid_x},${r.grid_y}`));
+
+  const LOCK_TTL_MS = 5 * 60 * 1000;
+
+  const handleCellClick = async (x: number, y: number) => {
+    const { data, error } = await supabase!
+      .from('rooms')
+      .insert([{ grid_x: x, grid_y: y, status: 'locking', locked_at: new Date().toISOString(), owner_id: myId }])
+      .select('id')
+      .single();
+    if (error || !data) return;
+    setReserving({ x, y, lockId: data.id });
+  };
 
   const handleReservationSuccess = (room: any, roomId: string) => {
-    setRooms(prev => [...prev, room]);
+    setRooms(prev => prev.map(r => r.id === room.id ? room : r));
     setReserving(null);
     setSuccessRoom({ room, roomId });
   };
@@ -155,8 +171,15 @@ function OpenRoomInner() {
         style={{ gridTemplateColumns: `repeat(${xRange.length}, 7rem)` }}
       >
         {yRange.map(y => xRange.map(x => {
-          const room = rooms.find(r => r.grid_x === x && r.grid_y === y);
+          const room = activeRooms.find(r => r.grid_x === x && r.grid_y === y);
           if (room) {
+            if (room.status === 'locking') {
+              return (
+                <div key={`${x}-${y}`} className="w-28 h-28 rounded-2xl border-2 border-dashed border-slate-200 bg-white flex items-center justify-center">
+                  <span className="text-[9px] uppercase tracking-widest text-slate-300 font-bold text-center px-2 leading-tight">Being<br/>Claimed</span>
+                </div>
+              );
+            }
             const isCommon = x === 0 && y === 0;
             return (
               <button
@@ -190,7 +213,7 @@ function OpenRoomInner() {
           const cellNum = availableCells.indexOf(`${x},${y}`) + 1;
 
           return (
-            <button key={`${x}-${y}`} onClick={() => setReserving({ x, y })} className="w-28 h-28 rounded-2xl border-2 border-dashed border-slate-300 hover:border-indigo-400 hover:bg-indigo-50 flex flex-col items-center justify-center text-slate-400 hover:text-indigo-500 transition-all gap-1">
+            <button key={`${x}-${y}`} onClick={() => handleCellClick(x, y)} className="w-28 h-28 rounded-2xl border-2 border-dashed border-slate-300 hover:border-indigo-400 hover:bg-indigo-50 flex flex-col items-center justify-center text-slate-400 hover:text-indigo-500 transition-all gap-1">
               <span className="font-bold text-[10px]">+ ADD ROOM</span>
               <span className="font-black text-sm leading-none opacity-60">{cellNum}</span>
             </button>
@@ -256,6 +279,7 @@ function OpenRoomInner() {
         <ReservationModal
           x={reserving.x}
           y={reserving.y}
+          lockId={reserving.lockId}
           onClose={() => setReserving(null)}
           onSuccess={handleReservationSuccess}
         />


### PR DESCRIPTION
Closes #148

## What changed
- Clicking a `+ ADD ROOM` cell immediately inserts a `status='locking'` row in Supabase — other users see a **"Being Claimed"** tile in real-time via the existing subscription
- `ReservationModal` now receives a `lockId` and **updates** that row on submit instead of inserting a new one, preserving the cell hold
- Cancelling the modal (backdrop click or close) **deletes** the lock row so the cell is freed immediately
- Stale locks (>5 min old) are filtered out of the floor plan so abandoned sessions don't block slots permanently

## Race condition handling
Two users clicking the same cell at the same millisecond: the second insert will fail (Supabase will reject it if a unique constraint exists on `grid_x, grid_y`), and the cell silently stays open for the winner — no error shown to the user who lost the race.